### PR TITLE
feat: create new folder during component copy

### DIFF
--- a/packages/cli/commands/copy.ts
+++ b/packages/cli/commands/copy.ts
@@ -11,6 +11,7 @@ import {
   jsonFileExtension,
   storiesFileExtension,
   packageVersion,
+  MAXIMUM_COMPONENTS_DIR_POSTFIX,
 } from '../shared/constants';
 import { generatePath } from '../utils/generatePath';
 import { installDependencies } from '../utils/installDependencies';
@@ -94,10 +95,22 @@ copy
     }
 
     for (const resultSrcPath of results.srcPath) {
-      const destinationDirectory = `${outputPath}/${path.basename(resultSrcPath)}`;
+      let destinationDirectory = `${outputPath}/${path.basename(resultSrcPath)}`;
+      const componentDirName = path.basename(resultSrcPath).replace(packageVersion + '/', '');
+
       const excludedExtensions = !results.shouldIncludeStories
         ? [jsonFileExtension, storiesFileExtension]
         : [jsonFileExtension];
+
+      if (fs.existsSync(destinationDirectory)) {
+        for (let index = 1; index < MAXIMUM_COMPONENTS_DIR_POSTFIX; index++) {
+          const componentDirWithPostfix = `${componentDirName}_${index}`;
+          if (!fs.existsSync(destinationDirectory.replace(componentDirName, componentDirWithPostfix))) {
+            destinationDirectory = `${outputPath}/${componentDirWithPostfix}`;
+            break;
+          }
+        }
+      }
 
       try {
         await copyAwsFolderWithExclusion({

--- a/packages/cli/shared/constants.ts
+++ b/packages/cli/shared/constants.ts
@@ -23,6 +23,8 @@ export const packageManagers = ['npm', 'yarn'];
 /* eslint-disable @typescript-eslint/no-var-requires */
 export const { version: packageVersion } = require('../../../package.json');
 
-export const COMPONENT_ITEMS_BUCKET = process.env.S3_BUCKET_COMPONENT_ITEMS || '';
+export const COMPONENT_ITEMS_BUCKET = process.env.S3_BUCKET_COMPONENT_ITEMS || 'tsh-frontend-components-items-catalog';
 
 export const EXCLUDED_BASE_S3_PATHS = [`${packageVersion}/.`, `${packageVersion}/`, `.`];
+
+export const MAXIMUM_COMPONENTS_DIR_POSTFIX = 10;

--- a/packages/cli/utils/copyAwsFolderWithExclusion.ts
+++ b/packages/cli/utils/copyAwsFolderWithExclusion.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import { ListObjectsV2Output } from '@aws-sdk/client-s3';
 
-import { COMPONENT_ITEMS_BUCKET, packageVersion } from '../shared/constants';
+import { COMPONENT_ITEMS_BUCKET } from '../shared/constants';
 
 import { getS3Object } from './getS3Object';
 import { logger } from './logger';
@@ -38,12 +38,10 @@ export const copyAwsFolderWithExclusion = async ({
       }
 
       const getObjectItem = await getS3Object(COMPONENT_ITEMS_BUCKET, object.Key as string);
-      const destinationDirName = `${path.dirname(destinationDirectory)}/`;
-      const filePath = `${destinationDirName}${object.Key?.replace(packageVersion, '')}`;
-      const dirName = `${destinationDirName}${path.dirname(object.Key || '').replace(packageVersion, '')}`;
+      const filePath = `${destinationDirectory}/${path.basename(object.Key || '')}`;
 
-      if (!fs.existsSync(dirName)) {
-        fs.mkdirSync(dirName, { recursive: true });
+      if (!fs.existsSync(destinationDirectory)) {
+        fs.mkdirSync(destinationDirectory, { recursive: true });
       }
 
       if (!fs.existsSync(filePath) && getObjectItem) {


### PR DESCRIPTION
When copying a component, it is checked whether the destination folder exists or not.
If the folder does not exist, a folder with the component name will be created.
If the folder with the component name exists, another folder named `componentName_number` will be created.